### PR TITLE
Add data-backed task-queue comparison page (kept fresh by CI)

### DIFF
--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -1,0 +1,30 @@
+name: stats
+
+on:
+  schedule:
+    - cron: "0 6 1 * *"
+  workflow_dispatch:
+
+jobs:
+  stats:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout repo
+        uses: actions/checkout@v4
+      - name: install uv
+        uses: astral-sh/setup-uv@v5
+      - name: refresh task-queue download stats
+        run: make stats
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.QMBOT_GITHUB_TOKEN }}
+          author: qmbot <bot@quantmind.com>
+          commit-message: refresh task-queue download stats
+          title: Refresh task-queue download stats
+          body: >
+            Auto-generated monthly refresh of the download table in
+            docs/comparison.md, produced by `make stats`.
+          branch: ci-task-queue-stats
+          labels: ci, automated pr

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,10 @@ release:		## tag current version (from pyproject.toml) and push
 		echo "Aborted."; \
 	fi
 
+.PHONY: stats
+stats:			## refresh task-queue download stats in docs/comparison.md
+	@uv run python scripts/task_queue_stats.py
+
 .PHONY: taplo-fmt
 taplo-fmt:		## format toml files with taplo
 	taplo fmt

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -1,0 +1,98 @@
+# Python task queues compared
+
+Python has a crowded field of task queues, and picking one is mostly about matching a
+library to how your service is shaped. This page lays out the landscape honestly — with
+real download data — and explains where `aio-fluid` does, and does not, make sense.
+
+If you are choosing for the first time, the short version:
+
+- **You want the biggest ecosystem and battle-tested defaults** → [Celery](https://docs.celeryq.dev/).
+- **You want something simple and Redis-only** → [RQ](https://python-rq.org/).
+- **You run an async (`asyncio`) service and your tasks never block the loop** → an
+  async-native queue like [arq](https://arq-docs.helpmanual.io/) or
+  [taskiq](https://taskiq-python.github.io/).
+- **You run an async service *and* some tasks are CPU-heavy** — parsing, pandas, model
+  scoring, rendering — that would otherwise freeze your event loop → this is exactly what
+  `aio-fluid` is built for. See [CPU bound tasks](tutorials/task_queue.md#cpu-bound-tasks)
+  and [K8s Jobs](tutorials/task_k8s.md).
+
+## Popularity
+
+Is Celery still the one everyone uses? Yes — decisively. It out-downloads the nearest real
+queue (RQ) by roughly an order of magnitude, and the async-native niche that `aio-fluid`
+competes in is comparatively small. That is both the opportunity (few libraries own
+"async-native + CPU-bound") and an honest reality check on the size of that audience.
+
+<!-- STATS:START -->
+_Downloads = last 30 days on PyPI, via [pypistats.org](https://pypistats.org). Seeded figures — run `make stats` to refresh and re-rank from live data. Counts are inflated by CI, mirrors and Docker builds — read them as orders of magnitude, not user counts._
+
+| Library | Downloads / mo | Async-native | CPU work off the loop | Notes |
+|---|---:|:---:|:---:|---|
+| [Celery](https://pypi.org/project/celery/) | 48.9M | partial | separate worker fleet | The incumbent — biggest ecosystem, broker-agnostic. |
+| [APScheduler](https://pypi.org/project/apscheduler/) | 37.1M | ✅ | n/a | A *scheduler*, not a distributed queue — listed for scale. |
+| [RQ](https://pypi.org/project/rq/) | 2.4M | — | separate worker | Simple, Redis-only; the common 'lite Celery'. |
+| [Dramatiq](https://pypi.org/project/dramatiq/) | 270k | — | separate worker | Ergonomic Celery alternative. |
+| [Huey](https://pypi.org/project/huey/) | 117k | — | separate worker | Lightweight, very few dependencies. |
+| [taskiq](https://pypi.org/project/taskiq/) | 34k | ✅ | no | Async-native, pluggable brokers; typed parameters. |
+| [arq](https://pypi.org/project/arq/) | — | ✅ | no | Async-native, Redis; count pending first `make stats`. |
+| [SAQ](https://pypi.org/project/saq/) | — | ✅ | no | Async-native, Redis; count pending first `make stats`. |
+| [Procrastinate](https://pypi.org/project/procrastinate/) | — | ✅ | no | Async-native, Postgres-backed; count pending first `make stats`. |
+| [aio-fluid](https://pypi.org/project/aio-fluid/) | 4k | ✅ | subprocess / k8s Job | This library — CPU-bound work is a first-class task type. |
+<!-- STATS:END -->
+
+## The libraries
+
+**Celery** is the default answer for a reason: the largest ecosystem, broker flexibility
+(RabbitMQ, Redis, SQS…), and years of production hardening. It predates `asyncio`, though,
+and its standard answer to CPU-bound work is to run a separate worker fleet. If you need
+breadth and maturity, reach for Celery.
+
+**RQ** is the "simple Celery": Redis-only, small API, easy to reason about. Synchronous by
+design — great for straightforward background jobs, not aimed at async services.
+
+**Dramatiq** is an ergonomic, well-designed Celery alternative with a cleaner API and
+retries/middleware built in. Still a worker-per-process model rather than async-native.
+
+**Huey** is deliberately tiny and dependency-light — a good fit for small projects that
+want a queue without operational weight.
+
+**arq**, **taskiq**, **SAQ** and **Procrastinate** are the async-native cohort. They run
+`async def` tasks on the event loop and are excellent for IO-bound work. By design they
+assume tasks do not block the loop, so CPU-bound work is out of scope — the same limitation
+that motivated `aio-fluid`.
+
+**APScheduler** is included only for scale: it is a *scheduler* (fire a job on an interval
+or cron), not a broker-backed distributed queue, so it solves a different problem.
+
+## Where aio-fluid fits
+
+`aio-fluid` is an async-native queue like arq/taskiq — but it treats CPU-bound work as a
+first-class task type instead of assuming it away. Mark a task
+[`cpu_bound=True`](tutorials/task_queue.md#cpu-bound-tasks) and it runs in a **fresh
+subprocess** so heavy work never blocks the event loop; when the consumer runs inside
+Kubernetes, the *same task* dispatches as a [Kubernetes Job](tutorials/task_k8s.md) instead
+— with no code change and no parallel worker deployment to maintain.
+
+So the honest positioning is not "Celery killer." It is: **if you run an async service and
+have ever watched one CPU-heavy task freeze the whole thing, `aio-fluid` is built for that
+specific pain.** If you have no CPU-bound work, a lighter async queue will serve you just as
+well; if you need Celery's ecosystem, use Celery.
+
+## Caveats on the numbers
+
+PyPI download counts are a rough popularity proxy, not a user count. They are inflated by
+CI/CD pipelines, Docker image builds, and mirrors, and libraries that are transitive
+dependencies of popular packages (Celery, APScheduler) are inflated the most. Treat every
+figure above as an order of magnitude. A `—` means the count has not been fetched yet.
+
+## Refreshing this table
+
+The table above is regenerated from live data by `scripts/task_queue_stats.py`:
+
+```bash
+make stats
+```
+
+It fetches last-30-days downloads from the [pypistats.org](https://pypistats.org) API for
+the curated library list, re-ranks the table, and rewrites the region between the `STATS`
+marker comments in this page. Run it before a release, or whenever the numbers look stale.

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -1,43 +1,43 @@
 # Python task queues compared
 
 Python has a crowded field of task queues, and picking one is mostly about matching a
-library to how your service is shaped. This page lays out the landscape honestly — with
-real download data — and explains where `aio-fluid` does, and does not, make sense.
+library to how your service is shaped. This page lays out the landscape honestly, with
+real download data, and explains where `aio-fluid` does, and does not, make sense.
 
 If you are choosing for the first time, the short version:
 
-- **You want the biggest ecosystem and battle-tested defaults** → [Celery](https://docs.celeryq.dev/).
-- **You want something simple and Redis-only** → [RQ](https://python-rq.org/).
-- **You run an async (`asyncio`) service and your tasks never block the loop** → an
+- **You want the biggest ecosystem and battle-tested defaults**: [Celery](https://docs.celeryq.dev/).
+- **You want something simple and Redis-only**: [RQ](https://python-rq.org/).
+- **You run an async (`asyncio`) service and your tasks never block the loop**: an
   async-native queue like [arq](https://arq-docs.helpmanual.io/) or
   [taskiq](https://taskiq-python.github.io/).
-- **You run an async service *and* some tasks are CPU-heavy** — parsing, pandas, model
-  scoring, rendering — that would otherwise freeze your event loop → this is exactly what
+- **You run an async service *and* some tasks are CPU-heavy** (parsing, pandas, model
+  scoring, rendering) that would otherwise freeze your event loop: this is exactly what
   `aio-fluid` is built for. See [CPU bound tasks](tutorials/task_queue.md#cpu-bound-tasks)
   and [K8s Jobs](tutorials/task_k8s.md).
 
 ## Popularity
 
-Is Celery still the one everyone uses? Yes — decisively. It out-downloads the nearest real
+Is Celery still the one everyone uses? Yes, decisively. It out-downloads the nearest real
 queue (RQ) by roughly an order of magnitude, and the async-native niche that `aio-fluid`
 competes in is comparatively small. That is both the opportunity (few libraries own
 "async-native + CPU-bound") and an honest reality check on the size of that audience.
 
 <!-- STATS:START -->
-_Downloads = last 30 days on PyPI, via [pypistats.org](https://pypistats.org). Seeded figures — run `make stats` to refresh and re-rank from live data. Counts are inflated by CI, mirrors and Docker builds — read them as orders of magnitude, not user counts._
+_Downloads = last 30 days on PyPI, via [pypistats.org](https://pypistats.org). Seeded figures; run `make stats` to refresh and re-rank from live data. Counts are inflated by CI, mirrors and Docker builds, so read them as orders of magnitude, not user counts._
 
 | Library | Downloads / mo | Async-native | CPU work off the loop | Notes |
 |---|---:|:---:|:---:|---|
-| [Celery](https://pypi.org/project/celery/) | 48.9M | partial | separate worker fleet | The incumbent — biggest ecosystem, broker-agnostic. |
-| [APScheduler](https://pypi.org/project/apscheduler/) | 37.1M | ✅ | n/a | A *scheduler*, not a distributed queue — listed for scale. |
-| [RQ](https://pypi.org/project/rq/) | 2.4M | — | separate worker | Simple, Redis-only; the common 'lite Celery'. |
-| [Dramatiq](https://pypi.org/project/dramatiq/) | 270k | — | separate worker | Ergonomic Celery alternative. |
-| [Huey](https://pypi.org/project/huey/) | 117k | — | separate worker | Lightweight, very few dependencies. |
+| [Celery](https://pypi.org/project/celery/) | 48.9M | partial | separate worker fleet | The incumbent: biggest ecosystem, broker-agnostic. |
+| [APScheduler](https://pypi.org/project/apscheduler/) | 37.1M | ✅ | n/a | A *scheduler*, not a distributed queue, listed for scale. |
+| [RQ](https://pypi.org/project/rq/) | 2.4M | no | separate worker | Simple, Redis-only; the common 'lite Celery'. |
+| [Dramatiq](https://pypi.org/project/dramatiq/) | 270k | no | separate worker | Ergonomic Celery alternative. |
+| [Huey](https://pypi.org/project/huey/) | 117k | no | separate worker | Lightweight, very few dependencies. |
 | [taskiq](https://pypi.org/project/taskiq/) | 34k | ✅ | no | Async-native, pluggable brokers; typed parameters. |
-| [arq](https://pypi.org/project/arq/) | — | ✅ | no | Async-native, Redis; count pending first `make stats`. |
-| [SAQ](https://pypi.org/project/saq/) | — | ✅ | no | Async-native, Redis; count pending first `make stats`. |
-| [Procrastinate](https://pypi.org/project/procrastinate/) | — | ✅ | no | Async-native, Postgres-backed; count pending first `make stats`. |
-| [aio-fluid](https://pypi.org/project/aio-fluid/) | 4k | ✅ | subprocess / k8s Job | This library — CPU-bound work is a first-class task type. |
+| [arq](https://pypi.org/project/arq/) | n/a | ✅ | no | Async-native, Redis; count pending first `make stats`. |
+| [SAQ](https://pypi.org/project/saq/) | n/a | ✅ | no | Async-native, Redis; count pending first `make stats`. |
+| [Procrastinate](https://pypi.org/project/procrastinate/) | n/a | ✅ | no | Async-native, Postgres-backed; count pending first `make stats`. |
+| [aio-fluid](https://pypi.org/project/aio-fluid/) | 4k | ✅ | subprocess / k8s Job | This library: CPU-bound work is a first-class task type. |
 <!-- STATS:END -->
 
 ## The libraries
@@ -48,42 +48,43 @@ and its standard answer to CPU-bound work is to run a separate worker fleet. If 
 breadth and maturity, reach for Celery.
 
 **RQ** is the "simple Celery": Redis-only, small API, easy to reason about. Synchronous by
-design — great for straightforward background jobs, not aimed at async services.
+design, so it is great for straightforward background jobs but not aimed at async services.
 
 **Dramatiq** is an ergonomic, well-designed Celery alternative with a cleaner API and
 retries/middleware built in. Still a worker-per-process model rather than async-native.
 
-**Huey** is deliberately tiny and dependency-light — a good fit for small projects that
+**Huey** is deliberately tiny and dependency-light, a good fit for small projects that
 want a queue without operational weight.
 
 **arq**, **taskiq**, **SAQ** and **Procrastinate** are the async-native cohort. They run
 `async def` tasks on the event loop and are excellent for IO-bound work. By design they
-assume tasks do not block the loop, so CPU-bound work is out of scope — the same limitation
-that motivated `aio-fluid`.
+assume tasks do not block the loop, so CPU-bound work is out of scope. That is the same
+limitation that motivated `aio-fluid`.
 
 **APScheduler** is included only for scale: it is a *scheduler* (fire a job on an interval
 or cron), not a broker-backed distributed queue, so it solves a different problem.
 
 ## Where aio-fluid fits
 
-`aio-fluid` is an async-native queue like arq/taskiq — but it treats CPU-bound work as a
+`aio-fluid` is an async-native queue like arq/taskiq, but it treats CPU-bound work as a
 first-class task type instead of assuming it away. Mark a task
 [`cpu_bound=True`](tutorials/task_queue.md#cpu-bound-tasks) and it runs in a **fresh
 subprocess** so heavy work never blocks the event loop; when the consumer runs inside
-Kubernetes, the *same task* dispatches as a [Kubernetes Job](tutorials/task_k8s.md) instead
-— with no code change and no parallel worker deployment to maintain.
+Kubernetes, the *same task* dispatches as a [Kubernetes Job](tutorials/task_k8s.md) instead,
+with no code change and no parallel worker deployment to maintain.
 
-So the honest positioning is not "Celery killer." It is: **if you run an async service and
-have ever watched one CPU-heavy task freeze the whole thing, `aio-fluid` is built for that
-specific pain.** If you have no CPU-bound work, a lighter async queue will serve you just as
-well; if you need Celery's ecosystem, use Celery.
+So the honest positioning is not "Celery killer." It is this: **if you run an async service
+and have ever watched one CPU-heavy task freeze the whole thing, `aio-fluid` is built for
+that specific pain.** If you have no CPU-bound work, a lighter async queue will serve you
+just as well; if you need Celery's ecosystem, use Celery.
 
 ## Caveats on the numbers
 
 PyPI download counts are a rough popularity proxy, not a user count. They are inflated by
 CI/CD pipelines, Docker image builds, and mirrors, and libraries that are transitive
 dependencies of popular packages (Celery, APScheduler) are inflated the most. Treat every
-figure above as an order of magnitude. A `—` means the count has not been fetched yet.
+figure above as an order of magnitude. A value of `n/a` means the count has not been
+fetched yet.
 
 ## Refreshing this table
 

--- a/scripts/task_queue_stats.py
+++ b/scripts/task_queue_stats.py
@@ -1,0 +1,216 @@
+"""Refresh the Python task-queue download table in ``docs/comparison.md``.
+
+The comparison page carries a small table of PyPI download counts so readers can
+see, with real data, how ``aio-fluid`` sits in the task-queue landscape. Those
+numbers go stale quickly, so this script regenerates them from the public
+`pypistats.org <https://pypistats.org>`_ API and rewrites the table in place
+(between the ``STATS`` marker comments).
+
+Run it with::
+
+    make stats                            # or:
+    uv run python scripts/task_queue_stats.py
+    uv run python scripts/task_queue_stats.py --json   # print data, page untouched
+
+The set of libraries and their qualitative columns (async-native, how CPU work
+is handled) are curated here; only the download numbers are fetched.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+API = "https://pypistats.org/api/packages/{package}/recent"
+DOCS_PAGE = Path(__file__).resolve().parent.parent / "docs" / "comparison.md"
+START = "<!-- STATS:START -->"
+END = "<!-- STATS:END -->"
+
+
+@dataclass(frozen=True)
+class Library:
+    """A task-queue library and how it handles the two axes that matter here."""
+
+    package: str
+    name: str
+    async_support: str  # "yes" / "partial" / "no"
+    cpu_off_loop: str  # how CPU-bound work is kept off the event loop
+    note: str
+
+
+# Curated landscape. Download counts are fetched; everything else is editorial.
+LIBRARIES: tuple[Library, ...] = (
+    Library(
+        "celery",
+        "Celery",
+        "partial",
+        "separate worker fleet",
+        "The incumbent — biggest ecosystem, broker-agnostic.",
+    ),
+    Library(
+        "apscheduler",
+        "APScheduler",
+        "yes",
+        "n/a",
+        "A *scheduler*, not a distributed queue — listed for scale.",
+    ),
+    Library(
+        "rq",
+        "RQ",
+        "no",
+        "separate worker",
+        "Simple, Redis-only; the common 'lite Celery'.",
+    ),
+    Library(
+        "dramatiq",
+        "Dramatiq",
+        "no",
+        "separate worker",
+        "Ergonomic Celery alternative.",
+    ),
+    Library(
+        "huey",
+        "Huey",
+        "no",
+        "separate worker",
+        "Lightweight, very few dependencies.",
+    ),
+    Library(
+        "arq",
+        "arq",
+        "yes",
+        "no",
+        "Async-native, Redis; assumes tasks never block the loop.",
+    ),
+    Library(
+        "taskiq",
+        "taskiq",
+        "yes",
+        "no",
+        "Async-native, pluggable brokers; typed parameters.",
+    ),
+    Library(
+        "saq",
+        "SAQ",
+        "yes",
+        "no",
+        "Async-native, Redis; small and fast.",
+    ),
+    Library(
+        "procrastinate",
+        "Procrastinate",
+        "yes",
+        "no",
+        "Async-native, Postgres-backed.",
+    ),
+    Library(
+        "aio-fluid",
+        "aio-fluid",
+        "yes",
+        "subprocess / k8s Job",
+        "This library — CPU-bound work is a first-class task type.",
+    ),
+)
+
+_SUPPORT = {"yes": "✅", "partial": "partial", "no": "—"}
+
+
+def fetch_last_month(package: str, *, timeout: float = 30.0) -> int | None:
+    """Return the last-30-days download count for ``package`` (``None`` on error)."""
+    request = urllib.request.Request(
+        API.format(package=package),
+        headers={"User-Agent": "aio-fluid-stats (+https://fluid.quantmind.com)"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            payload = json.load(response)
+        return int(payload["data"]["last_month"])
+    except (urllib.error.URLError, TimeoutError, KeyError, ValueError) as exc:
+        print(f"warning: could not fetch {package}: {exc}", file=sys.stderr)
+        return None
+
+
+def humanize(count: int | None) -> str:
+    """Render a download count compactly: ``48.9M``, ``117k``, ``898``, ``—``."""
+    if count is None:
+        return "—"
+    if count >= 1_000_000:
+        return f"{count / 1_000_000:.1f}M"
+    if count >= 1_000:
+        return f"{count / 1_000:.0f}k"
+    return str(count)
+
+
+def render_table(rows: list[tuple[Library, int | None]], *, today: str) -> str:
+    """Render the ranked markdown table (excluding the surrounding markers)."""
+    lines = [
+        "_Downloads = last 30 days on PyPI, via "
+        "[pypistats.org](https://pypistats.org). "
+        f"Last refreshed {today}. Counts are inflated by CI, mirrors and Docker "
+        "builds — read them as orders of magnitude, not user counts._",
+        "",
+        "| Library | Downloads / mo | Async-native | CPU work off the loop | Notes |",
+        "|---|---:|:---:|:---:|---|",
+    ]
+    for library, count in rows:
+        lines.append(
+            f"| [{library.name}](https://pypi.org/project/{library.package}/) "
+            f"| {humanize(count)} "
+            f"| {_SUPPORT[library.async_support]} "
+            f"| {library.cpu_off_loop} "
+            f"| {library.note} |"
+        )
+    return "\n".join(lines)
+
+
+def splice(content: str, table: str) -> str:
+    """Replace the text between the ``STATS`` markers with ``table``."""
+    if START not in content or END not in content:
+        raise SystemExit(f"markers {START} / {END} not found in {DOCS_PAGE}")
+    before = content[: content.index(START) + len(START)]
+    after = content[content.index(END) :]
+    return f"{before}\n{table}\n{after}"
+
+
+def collect() -> list[tuple[Library, int | None]]:
+    """Fetch every library's downloads and rank them, highest first."""
+    rows = [(library, fetch_last_month(library.package)) for library in LIBRARIES]
+    rows.sort(key=lambda row: (row[1] is None, -(row[1] or 0)))
+    return rows
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="print the collected data as JSON and leave the docs page untouched",
+    )
+    args = parser.parse_args()
+
+    rows = collect()
+
+    if args.json:
+        print(
+            json.dumps(
+                {library.package: count for library, count in rows},
+                indent=2,
+            )
+        )
+        return
+
+    today = datetime.now(timezone.utc).date().isoformat()
+    table = render_table(rows, today=today)
+    content = DOCS_PAGE.read_text()
+    DOCS_PAGE.write_text(splice(content, table))
+    print(f"updated {DOCS_PAGE.relative_to(Path.cwd())} ({today})")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/task_queue_stats.py
+++ b/scripts/task_queue_stats.py
@@ -51,14 +51,14 @@ LIBRARIES: tuple[Library, ...] = (
         "Celery",
         "partial",
         "separate worker fleet",
-        "The incumbent — biggest ecosystem, broker-agnostic.",
+        "The incumbent: biggest ecosystem, broker-agnostic.",
     ),
     Library(
         "apscheduler",
         "APScheduler",
         "yes",
         "n/a",
-        "A *scheduler*, not a distributed queue — listed for scale.",
+        "A *scheduler*, not a distributed queue, listed for scale.",
     ),
     Library(
         "rq",
@@ -114,11 +114,11 @@ LIBRARIES: tuple[Library, ...] = (
         "aio-fluid",
         "yes",
         "subprocess / k8s Job",
-        "This library — CPU-bound work is a first-class task type.",
+        "This library: CPU-bound work is a first-class task type.",
     ),
 )
 
-_SUPPORT = {"yes": "✅", "partial": "partial", "no": "—"}
+_SUPPORT = {"yes": "✅", "partial": "partial", "no": "no"}
 
 
 def fetch_last_month(package: str, *, timeout: float = 30.0) -> int | None:
@@ -137,9 +137,9 @@ def fetch_last_month(package: str, *, timeout: float = 30.0) -> int | None:
 
 
 def humanize(count: int | None) -> str:
-    """Render a download count compactly: ``48.9M``, ``117k``, ``898``, ``—``."""
+    """Render a download count compactly: ``48.9M``, ``117k``, ``898``, ``n/a``."""
     if count is None:
-        return "—"
+        return "n/a"
     if count >= 1_000_000:
         return f"{count / 1_000_000:.1f}M"
     if count >= 1_000:
@@ -153,7 +153,7 @@ def render_table(rows: list[tuple[Library, int | None]], *, today: str) -> str:
         "_Downloads = last 30 days on PyPI, via "
         "[pypistats.org](https://pypistats.org). "
         f"Last refreshed {today}. Counts are inflated by CI, mirrors and Docker "
-        "builds — read them as orders of magnitude, not user counts._",
+        "builds, read them as orders of magnitude, not user counts._",
         "",
         "| Library | Downloads / mo | Async-native | CPU work off the loop | Notes |",
         "|---|---:|:---:|:---:|---|",

--- a/tests/test_task_queue_stats.py
+++ b/tests/test_task_queue_stats.py
@@ -1,0 +1,56 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+pytestmark = pytest.mark.asyncio(loop_scope="module")
+
+SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "task_queue_stats.py"
+
+
+def _load() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("task_queue_stats", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    # register before exec so dataclass field resolution can find the module
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+stats = _load()
+
+
+async def test_humanize() -> None:
+    assert stats.humanize(48_929_015) == "48.9M"
+    assert stats.humanize(2_400_000) == "2.4M"
+    assert stats.humanize(117_240) == "117k"
+    assert stats.humanize(898) == "898"
+    assert stats.humanize(None) == "—"
+
+
+async def test_render_table_contains_rows() -> None:
+    rows = [(library, 1000) for library in stats.LIBRARIES]
+    table = stats.render_table(rows, today="2026-08-01")
+    assert "Downloads / mo" in table
+    assert "Last refreshed 2026-08-01" in table
+    # every library shows up as a linked cell
+    for library in stats.LIBRARIES:
+        assert f"[{library.name}](https://pypi.org/project/{library.package}/)" in table
+
+
+async def test_splice_replaces_only_between_markers() -> None:
+    original = f"head\n{stats.START}\nOLD BODY\n{stats.END}\ntail"
+    updated = stats.splice(original, "NEW BODY")
+    assert "NEW BODY" in updated
+    assert "OLD BODY" not in updated
+    assert updated.startswith("head")
+    assert updated.endswith("tail")
+    assert stats.START in updated and stats.END in updated
+
+
+async def test_splice_requires_markers() -> None:
+    with pytest.raises(SystemExit):
+        stats.splice("no markers here", "NEW BODY")

--- a/tests/test_task_queue_stats.py
+++ b/tests/test_task_queue_stats.py
@@ -28,7 +28,7 @@ async def test_humanize() -> None:
     assert stats.humanize(2_400_000) == "2.4M"
     assert stats.humanize(117_240) == "117k"
     assert stats.humanize(898) == "898"
-    assert stats.humanize(None) == "—"
+    assert stats.humanize(None) == "n/a"
 
 
 async def test_render_table_contains_rows() -> None:


### PR DESCRIPTION
Follow-up to #104. Adds a dedicated comparison page grounding the "why not just use Celery?" question in real download data, plus the tooling to keep those numbers from going stale. Self-contained; no library code changes.

## Changes

- **`docs/comparison.md`** — honest landscape of Python task queues (Celery, RQ, Dramatiq, Huey, arq, taskiq, SAQ, Procrastinate, APScheduler, aio-fluid) with per-library notes and a clear-eyed "where aio-fluid fits" (async-native queue that treats CPU-bound work as first-class — *not* a Celery killer). Auto-appears in the mkdocs nav.
- **`scripts/task_queue_stats.py`** — stdlib-only (no new deps); fetches last-30-days downloads from the [pypistats.org](https://pypistats.org) API, re-ranks, and rewrites the table between the `STATS` markers in the page.
- **`make stats`** — Makefile target to run it.
- **`.github/workflows/stats.yml`** — monthly (+ manual) job that runs `make stats` and opens a PR when the table changes. Mirrors the existing `freeze` workflow (same `qmbot` author / `QMBOT_GITHUB_TOKEN` / `create-pull-request`), so numbers refresh through review.
- **Tests** — network-free coverage of number formatting, table rendering, and marker splicing.

## Data note

The committed table is **seeded** and re-ranks itself on the first `make stats` run in a network-enabled environment (the sandbox this was authored in blocks pypistats.org, so `arq`/`SAQ`/`Procrastinate` currently show `—`). Worth running `make stats` once before merge so it ships with live figures. Headline finding: Celery still dominates (~49M downloads/mo, ~20× the nearest real queue); the async-native niche aio-fluid competes in is small.

## Verification

- `mkdocs build` passes with `strict: true` (all links resolve).
- `make lint` clean (ruff + black + isort + mypy); new tests green.
- No Python library source touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QguqgPhVET9Jc2eihYuFFx)_