### PR TITLE
Fix landing: remove em dashes, rewrite the hero example, add prose rule

### DIFF
--- a/.github/instructions/code.instructions.md
+++ b/.github/instructions/code.instructions.md
@@ -15,7 +15,9 @@
 ## Prose style
 
 - Never use em dashes (`—`), en dashes (`–`) as sentence punctuation, or `--`
-  in prose. This applies to all Markdown, docstrings, the README, release
-  notes, code comments, and commit/PR text. Use a comma, colon, semicolon,
-  or parentheses, or split the sentence into two. Ordinary hyphens in
-  compound words (`CPU-bound`, `async-native`) are correct and stay.
+  in the main text body. This means the rendered prose a reader sees: all
+  Markdown body text, docstrings, the README, release notes, code comments,
+  and commit/PR text. Use a comma, colon, semicolon, or parentheses, or split
+  the sentence into two. Ordinary hyphens in compound words (`CPU-bound`,
+  `async-native`) are correct and stay, and non-prose such as HTML attribute
+  values (for example an image `alt`) is out of scope.

--- a/.github/instructions/code.instructions.md
+++ b/.github/instructions/code.instructions.md
@@ -11,3 +11,11 @@
   The docs build runs in strict mode and fails on unresolved references.
 - After changing docstrings or anything under `docs/`, run `make docs` to
   verify the strict build passes.
+
+## Prose style
+
+- Never use em dashes (`—`), en dashes (`–`) as sentence punctuation, or `--`
+  in prose. This applies to all Markdown, docstrings, the README, release
+  notes, code comments, and commit/PR text. Use a comma, colon, semicolon,
+  or parentheses, or split the sentence into two. Ordinary hyphens in
+  compound words (`CPU-bound`, `async-native`) are correct and stay.

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,38 +32,34 @@ from fluid.scheduler import TaskScheduler, TaskRun, task, every
 
 
 class Report(BaseModel):
-    rows: int = 1_000_000
+    rows: int = 5_000_000
 
 
-# IO-bound task: runs concurrently on the event loop.
-@task
-async def fetch(ctx: TaskRun) -> None:
-    ctx.task_manager.queue("crunch", rows=5_000_000)
-
-
-# CPU-bound task: same decorator, one flag. Runs in a subprocess so blocking
-# is fine. Inside a Kubernetes cluster it runs as a Job instead, no code change.
-@task(cpu_bound=True, timeout_seconds=600)
-async def crunch(ctx: TaskRun[Report]) -> None:
-    heavy_pandas_work(ctx.params.rows)  # blocking CPU work, safely isolated
-
-
-# Scheduled task: interval or cron, for IO- and CPU-bound tasks alike.
-@task(schedule=every(timedelta(minutes=5)))
+# IO-bound task, scheduled every minute: runs concurrently on the event loop.
+@task(schedule=every(timedelta(minutes=1)))
 async def heartbeat(ctx: TaskRun) -> None:
     ctx.logger.info("still alive")
+
+
+# CPU-bound task, scheduled hourly: same decorator, one flag. Runs in a
+# subprocess (or a Kubernetes Job in-cluster) so the heavy work never blocks
+# the event loop. Identical code in both places.
+@task(cpu_bound=True, schedule=every(timedelta(hours=1)), timeout_seconds=600)
+async def crunch(ctx: TaskRun[Report]) -> None:
+    heavy_pandas_work(ctx.params.rows)
 
 
 async def main() -> None:
     scheduler = TaskScheduler()
     scheduler.register_from_dict(globals())
-    async with scheduler:
-        await scheduler.queue("fetch")
-        await asyncio.sleep(2)
+    await scheduler.run()  # run the scheduled tasks until interrupted
 
 
 asyncio.run(main())
 ```
+
+Need to fire a task on demand instead of on a schedule? Drop the `schedule=`
+and call `await scheduler.queue("crunch")` when you want it to run.
 
 ## Why aio-fluid?
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@
   </a>
 </h1>
 
-**An async task queue for Python that offloads CPU-bound work to subprocesses — or Kubernetes Jobs — without blocking your event loop.**
+**An async task queue for Python that offloads CPU-bound work to subprocesses (or Kubernetes Jobs) without blocking your event loop.**
 
 [![PyPI version](https://badge.fury.io/py/aio-fluid.svg)](https://badge.fury.io/py/aio-fluid)
 [![Python versions](https://img.shields.io/pypi/pyversions/aio-fluid.svg)](https://pypi.org/project/aio-fluid)
@@ -19,7 +19,7 @@
 
 Declare tasks with a `@task` decorator, schedule them with `every()` or cron, and run them
 concurrently on asyncio. The part that sets `aio-fluid` apart: mark a task `cpu_bound=True` and
-it runs in a **fresh subprocess** so heavy CPU work never freezes the event loop — and when your
+it runs in a **fresh subprocess** so heavy CPU work never freezes the event loop. And when your
 consumer runs inside Kubernetes, the *same task* dispatches as a **Kubernetes Job** instead, with
 **no code change**.
 
@@ -35,20 +35,20 @@ class Report(BaseModel):
     rows: int = 1_000_000
 
 
-# IO-bound task — runs concurrently on the event loop.
+# IO-bound task: runs concurrently on the event loop.
 @task
 async def fetch(ctx: TaskRun) -> None:
     ctx.task_manager.queue("crunch", rows=5_000_000)
 
 
-# CPU-bound task — same decorator, one flag. Runs in a subprocess so blocking
-# is fine. Inside a Kubernetes cluster it runs as a Job instead — no code change.
+# CPU-bound task: same decorator, one flag. Runs in a subprocess so blocking
+# is fine. Inside a Kubernetes cluster it runs as a Job instead, no code change.
 @task(cpu_bound=True, timeout_seconds=600)
 async def crunch(ctx: TaskRun[Report]) -> None:
     heavy_pandas_work(ctx.params.rows)  # blocking CPU work, safely isolated
 
 
-# Scheduled task — interval or cron, for IO- and CPU-bound tasks alike.
+# Scheduled task: interval or cron, for IO- and CPU-bound tasks alike.
 @task(schedule=every(timedelta(minutes=5)))
 async def heartbeat(ctx: TaskRun) -> None:
     ctx.logger.info("still alive")
@@ -74,7 +74,7 @@ answer for *"this one task is CPU-heavy"* beyond "spin up a second worker fleet.
 `aio-fluid` treats CPU-bound work as a first-class task type:
 
 - **One decorator, two execution models.** `@task(cpu_bound=True)` runs locally as a subprocess and
-  in-cluster as a Kubernetes Job — the switch is automatic (`KUBERNETES_SERVICE_HOST` + the `k8s`
+  in-cluster as a Kubernetes Job: the switch is automatic (`KUBERNETES_SERVICE_HOST` + the `k8s`
   extra). Your task code is identical in both. See [K8s Jobs](https://fluid.quantmind.com/tutorials/task_k8s/).
 - **Async-native and typed.** Tasks are plain `async def` functions; parameters are
   [pydantic](https://docs.pydantic.dev/) models, validated on the way in.
@@ -89,13 +89,13 @@ answer for *"this one task is CPU-heavy"* beyond "spin up a second worker fleet.
 |---|---|---|---|---|
 | Async-native (`async def` tasks) | ✅ | partial | ✅ | ✅ |
 | CPU-bound tasks off the event loop | ✅ subprocess | separate worker | ❌ | ❌ |
-| Same task → Kubernetes Job, no code change | ✅ | ❌ | ❌ | ❌ |
+| Same task as a Kubernetes Job, no code change | ✅ | ❌ | ❌ | ❌ |
 | Cron + interval scheduling built in | ✅ | via beat | ✅ | via scheduler |
 | Typed (pydantic) task parameters | ✅ | ❌ | ❌ | ✅ |
 | FastAPI integration | ✅ | ❌ | ❌ | partial |
 | Default broker | Redis | RabbitMQ/Redis | Redis | Redis/NATS/… |
 
-`Celery` is the mature, battle-tested default with the biggest ecosystem — reach for it when you
+`Celery` is the mature, battle-tested default with the biggest ecosystem; reach for it when you
 need that breadth. `aio-fluid` is for async services that want CPU-bound work handled natively and
 scaled onto Kubernetes without a parallel worker deployment.
 
@@ -104,11 +104,11 @@ scaled onto Kubernetes without a parallel worker deployment.
 Alongside the task queue, `aio-fluid` ships the building blocks Quantmind uses to run backend
 services:
 
-- **Async workers** — composable components with a managed start/stop lifecycle; the foundation the task queue is built on. See [Workers](https://fluid.quantmind.com/reference/workers/).
-- **Async Postgres CRUD** — a typed CRUD layer over `asyncpg` and SQLAlchemy, with pagination and schema migrations. See [Database](https://fluid.quantmind.com/reference/db/).
-- **Event dispatchers** — sync and async `Dispatcher` types for decoupling event sources from handlers. See [Dispatchers](https://fluid.quantmind.com/reference/dispatchers/).
-- **HTTP client helpers** — a unified async client wrapping `httpx` and `aiohttp`. See [HTTP Client](https://fluid.quantmind.com/reference/http_client/).
-- **CLI tooling** — ready-made `click` / `rich` command-line interfaces for task managers and databases.
+- **Async workers**: composable components with a managed start/stop lifecycle; the foundation the task queue is built on. See [Workers](https://fluid.quantmind.com/reference/workers/).
+- **Async Postgres CRUD**: a typed CRUD layer over `asyncpg` and SQLAlchemy, with pagination and schema migrations. See [Database](https://fluid.quantmind.com/reference/db/).
+- **Event dispatchers**: sync and async `Dispatcher` types for decoupling event sources from handlers. See [Dispatchers](https://fluid.quantmind.com/reference/dispatchers/).
+- **HTTP client helpers**: a unified async client wrapping `httpx` and `aiohttp`. See [HTTP Client](https://fluid.quantmind.com/reference/http_client/).
+- **CLI tooling**: ready-made `click` / `rich` command-line interfaces for task managers and databases.
 
 ## Installation
 

--- a/readme.md
+++ b/readme.md
@@ -32,38 +32,34 @@ from fluid.scheduler import TaskScheduler, TaskRun, task, every
 
 
 class Report(BaseModel):
-    rows: int = 1_000_000
+    rows: int = 5_000_000
 
 
-# IO-bound task: runs concurrently on the event loop.
-@task
-async def fetch(ctx: TaskRun) -> None:
-    ctx.task_manager.queue("crunch", rows=5_000_000)
-
-
-# CPU-bound task: same decorator, one flag. Runs in a subprocess so blocking
-# is fine. Inside a Kubernetes cluster it runs as a Job instead, no code change.
-@task(cpu_bound=True, timeout_seconds=600)
-async def crunch(ctx: TaskRun[Report]) -> None:
-    heavy_pandas_work(ctx.params.rows)  # blocking CPU work, safely isolated
-
-
-# Scheduled task: interval or cron, for IO- and CPU-bound tasks alike.
-@task(schedule=every(timedelta(minutes=5)))
+# IO-bound task, scheduled every minute: runs concurrently on the event loop.
+@task(schedule=every(timedelta(minutes=1)))
 async def heartbeat(ctx: TaskRun) -> None:
     ctx.logger.info("still alive")
+
+
+# CPU-bound task, scheduled hourly: same decorator, one flag. Runs in a
+# subprocess (or a Kubernetes Job in-cluster) so the heavy work never blocks
+# the event loop. Identical code in both places.
+@task(cpu_bound=True, schedule=every(timedelta(hours=1)), timeout_seconds=600)
+async def crunch(ctx: TaskRun[Report]) -> None:
+    heavy_pandas_work(ctx.params.rows)
 
 
 async def main() -> None:
     scheduler = TaskScheduler()
     scheduler.register_from_dict(globals())
-    async with scheduler:
-        await scheduler.queue("fetch")
-        await asyncio.sleep(2)
+    await scheduler.run()  # run the scheduled tasks until interrupted
 
 
 asyncio.run(main())
 ```
+
+Need to fire a task on demand instead of on a schedule? Drop the `schedule=`
+and call `await scheduler.queue("crunch")` when you want it to run.
 
 ## Why aio-fluid?
 

--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@
   </a>
 </h1>
 
-**An async task queue for Python that offloads CPU-bound work to subprocesses — or Kubernetes Jobs — without blocking your event loop.**
+**An async task queue for Python that offloads CPU-bound work to subprocesses (or Kubernetes Jobs) without blocking your event loop.**
 
 [![PyPI version](https://badge.fury.io/py/aio-fluid.svg)](https://badge.fury.io/py/aio-fluid)
 [![Python versions](https://img.shields.io/pypi/pyversions/aio-fluid.svg)](https://pypi.org/project/aio-fluid)
@@ -19,7 +19,7 @@
 
 Declare tasks with a `@task` decorator, schedule them with `every()` or cron, and run them
 concurrently on asyncio. The part that sets `aio-fluid` apart: mark a task `cpu_bound=True` and
-it runs in a **fresh subprocess** so heavy CPU work never freezes the event loop — and when your
+it runs in a **fresh subprocess** so heavy CPU work never freezes the event loop. And when your
 consumer runs inside Kubernetes, the *same task* dispatches as a **Kubernetes Job** instead, with
 **no code change**.
 
@@ -35,20 +35,20 @@ class Report(BaseModel):
     rows: int = 1_000_000
 
 
-# IO-bound task — runs concurrently on the event loop.
+# IO-bound task: runs concurrently on the event loop.
 @task
 async def fetch(ctx: TaskRun) -> None:
     ctx.task_manager.queue("crunch", rows=5_000_000)
 
 
-# CPU-bound task — same decorator, one flag. Runs in a subprocess so blocking
-# is fine. Inside a Kubernetes cluster it runs as a Job instead — no code change.
+# CPU-bound task: same decorator, one flag. Runs in a subprocess so blocking
+# is fine. Inside a Kubernetes cluster it runs as a Job instead, no code change.
 @task(cpu_bound=True, timeout_seconds=600)
 async def crunch(ctx: TaskRun[Report]) -> None:
     heavy_pandas_work(ctx.params.rows)  # blocking CPU work, safely isolated
 
 
-# Scheduled task — interval or cron, for IO- and CPU-bound tasks alike.
+# Scheduled task: interval or cron, for IO- and CPU-bound tasks alike.
 @task(schedule=every(timedelta(minutes=5)))
 async def heartbeat(ctx: TaskRun) -> None:
     ctx.logger.info("still alive")
@@ -74,7 +74,7 @@ answer for *"this one task is CPU-heavy"* beyond "spin up a second worker fleet.
 `aio-fluid` treats CPU-bound work as a first-class task type:
 
 - **One decorator, two execution models.** `@task(cpu_bound=True)` runs locally as a subprocess and
-  in-cluster as a Kubernetes Job — the switch is automatic (`KUBERNETES_SERVICE_HOST` + the `k8s`
+  in-cluster as a Kubernetes Job: the switch is automatic (`KUBERNETES_SERVICE_HOST` + the `k8s`
   extra). Your task code is identical in both. See [K8s Jobs](https://fluid.quantmind.com/tutorials/task_k8s/).
 - **Async-native and typed.** Tasks are plain `async def` functions; parameters are
   [pydantic](https://docs.pydantic.dev/) models, validated on the way in.
@@ -89,13 +89,13 @@ answer for *"this one task is CPU-heavy"* beyond "spin up a second worker fleet.
 |---|---|---|---|---|
 | Async-native (`async def` tasks) | ✅ | partial | ✅ | ✅ |
 | CPU-bound tasks off the event loop | ✅ subprocess | separate worker | ❌ | ❌ |
-| Same task → Kubernetes Job, no code change | ✅ | ❌ | ❌ | ❌ |
+| Same task as a Kubernetes Job, no code change | ✅ | ❌ | ❌ | ❌ |
 | Cron + interval scheduling built in | ✅ | via beat | ✅ | via scheduler |
 | Typed (pydantic) task parameters | ✅ | ❌ | ❌ | ✅ |
 | FastAPI integration | ✅ | ❌ | ❌ | partial |
 | Default broker | Redis | RabbitMQ/Redis | Redis | Redis/NATS/… |
 
-`Celery` is the mature, battle-tested default with the biggest ecosystem — reach for it when you
+`Celery` is the mature, battle-tested default with the biggest ecosystem; reach for it when you
 need that breadth. `aio-fluid` is for async services that want CPU-bound work handled natively and
 scaled onto Kubernetes without a parallel worker deployment.
 
@@ -104,11 +104,11 @@ scaled onto Kubernetes without a parallel worker deployment.
 Alongside the task queue, `aio-fluid` ships the building blocks Quantmind uses to run backend
 services:
 
-- **Async workers** — composable components with a managed start/stop lifecycle; the foundation the task queue is built on. See [Workers](https://fluid.quantmind.com/reference/workers/).
-- **Async Postgres CRUD** — a typed CRUD layer over `asyncpg` and SQLAlchemy, with pagination and schema migrations. See [Database](https://fluid.quantmind.com/reference/db/).
-- **Event dispatchers** — sync and async `Dispatcher` types for decoupling event sources from handlers. See [Dispatchers](https://fluid.quantmind.com/reference/dispatchers/).
-- **HTTP client helpers** — a unified async client wrapping `httpx` and `aiohttp`. See [HTTP Client](https://fluid.quantmind.com/reference/http_client/).
-- **CLI tooling** — ready-made `click` / `rich` command-line interfaces for task managers and databases.
+- **Async workers**: composable components with a managed start/stop lifecycle; the foundation the task queue is built on. See [Workers](https://fluid.quantmind.com/reference/workers/).
+- **Async Postgres CRUD**: a typed CRUD layer over `asyncpg` and SQLAlchemy, with pagination and schema migrations. See [Database](https://fluid.quantmind.com/reference/db/).
+- **Event dispatchers**: sync and async `Dispatcher` types for decoupling event sources from handlers. See [Dispatchers](https://fluid.quantmind.com/reference/dispatchers/).
+- **HTTP client helpers**: a unified async client wrapping `httpx` and `aiohttp`. See [HTTP Client](https://fluid.quantmind.com/reference/http_client/).
+- **CLI tooling**: ready-made `click` / `rich` command-line interfaces for task managers and databases.
 
 ## Installation
 


### PR DESCRIPTION
#104 was merged at its original state, *before* the em-dash cleanup, so `main`'s `docs/index.md` and `readme.md` still carry 14 em-dashes and the hero example is the weak version. This restarts the branch from current `main` and re-applies the outstanding fixes as a fresh change.

## Changes

- **Remove em dashes** from the landing page prose (`docs/index.md`, copied to `readme.md`); replace with commas, colons, and parentheses.
- **Add a prose style rule** in `.github/instructions/code.instructions.md`: no em dashes, en dashes, or `--` in the main text body (rendered prose, docstrings, README, release notes, code comments, commit/PR text), with non-prose like HTML `alt` attributes explicitly out of scope.
- **Rewrite the hero example.** The old version queued a task by hand in `main()` and slept, which is a poor way to show off a scheduler. The task can carry its own `every()` schedule. The example now declares two scheduled tasks (an IO-bound heartbeat and a `cpu_bound` crunch) and just runs the scheduler, with a one-line note on enqueuing on demand.

## Notes

- The comparison page (#105) already merged with its em dashes removed; this only concerns the landing page and the shared instruction file.
- Since #104 is merged, this is a new PR off `main`.

## Verification

- `mkdocs build` passes with `strict: true`.
- No Python source touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QguqgPhVET9Jc2eihYuFFx)_